### PR TITLE
another tweak we need: change module to segmentio/go-sqlite3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mattn/go-sqlite3
+module github.com/segmentio/go-sqlite3
 
 go 1.19
 


### PR DESCRIPTION
Since we renamed the repo, we need to also rename the module.

Without this change we get errors when trying to use this repo in ctlstore:

```
➜  ctlstore git:(master) ✗ go get github.com/segmentio/go-sqlite3@segment-v1.14.22
go: downloading github.com/segmentio/go-sqlite3 v1.14.23-0.20240208202956-73b5bef61db6
go: github.com/segmentio/go-sqlite3@segment-v1.14.22 (v1.14.23-0.20240208202956-73b5bef61db6) requires github.com/segmentio/go-sqlite3@v1.14.23-0.20240208202956-73b5bef61db6: parsing go.mod:
	module declares its path as: github.com/mattn/go-sqlite3
	        but was required as: github.com/segmentio/go-sqlite3
```

Testing completed successfully by running `go get` against this branch and seeing it succeed:

```
➜  ctlstore git:(master) ✗ go get github.com/segmentio/go-sqlite3@erikdw/update-go.mod
go: downloading github.com/segmentio/go-sqlite3 v1.14.23-0.20240215094832-276ee774daea
go: upgraded github.com/segmentio/go-sqlite3 v1.12.0 => v1.14.23-0.20240215094832-276ee774daea
```